### PR TITLE
Added dynamic application type fetching and related API endpoints

### DIFF
--- a/app/shared/services/auth-utils.service.js
+++ b/app/shared/services/auth-utils.service.js
@@ -124,7 +124,10 @@
                 }
             }
 
-            return availableTypes.indexOf('*') > -1 ? APPLICATION_TYPES : availableTypes;
+            var allTypes = $rootScope.APPLICATION_TYPES && $rootScope.APPLICATION_TYPES.length > 0 
+                ? $rootScope.APPLICATION_TYPES : APPLICATION_TYPES;
+            
+            return availableTypes.indexOf('*') > -1 ? allTypes : availableTypes;
         }
 
         function endsWithApplicationType(permission) {

--- a/app/shared/services/auth.service.js
+++ b/app/shared/services/auth.service.js
@@ -25,11 +25,16 @@
     function service($rootScope, $cookies, utilsService, PERMISSION, $http) {
         const API_URL = 'auth/info';
         return {
-            getAuthInfo: getAuthInfo
+            getAuthInfo: getAuthInfo,
+            getApplicationTypes: getApplicationTypes
         };
 
        async function getAuthInfo() {
            return $http.get(API_URL);
         };
+
+        function getApplicationTypes() {
+            return $http.get('/applicationtype/all');
+        }
     }
 })();

--- a/app/shared/services/auth.service.js
+++ b/app/shared/services/auth.service.js
@@ -34,7 +34,7 @@
         };
 
         function getApplicationTypes() {
-            return $http.get('/application-types/all');
+            return $http.get('/application-types');
         }
     }
 })();

--- a/app/shared/services/auth.service.js
+++ b/app/shared/services/auth.service.js
@@ -34,7 +34,7 @@
         };
 
         function getApplicationTypes() {
-            return $http.get('/applicationtype/all');
+            return $http.get('/application-types/all');
         }
     }
 })();

--- a/app/xconf/config/state.config.js
+++ b/app/xconf/config/state.config.js
@@ -36,6 +36,7 @@
 
                 restoreApplicationType();
                 setAdminUrlCookie();
+                fetchApplicationTypes();
 
                 function setAdminUrlCookie() {
                     $cookies.put('admin-ui-location', $window.location.origin);
@@ -49,6 +50,19 @@
                     }
                 }
 
+                // Fetching dynamic application types
+                function fetchApplicationTypes() {
+                    authService.getApplicationTypes().then(function (resp) {
+                        if (resp.data && resp.data.length > 0) {
+                            var appTypes = resp.data.map(function(appType) { return appType.name; });
+                            $rootScope.APPLICATION_TYPES = appTypes;
+                            $rootScope.availableApplicationTypes = appTypes;
+                        }
+                    }, function (error) {
+                        alertsService.showError({ title: 'Error', message: error.data.message });
+                    });
+                }
+                
                 authorizationService.getAuthProvider().then(function (resp) {
                     $rootScope.authProvider = resp.data.name;
                 }, function (error) {

--- a/app/xconf/config/state.config.js
+++ b/app/xconf/config/state.config.js
@@ -1,3 +1,5 @@
+const { log } = require("grunt");
+
 /**
  * Copyright 2024 Comcast Cable Communications Management, LLC
  *
@@ -57,9 +59,12 @@
                             var appTypes = resp.data.map(function(appType) { return appType.name; });
                             $rootScope.APPLICATION_TYPES = appTypes;
                             $rootScope.availableApplicationTypes = appTypes;
+                        }else{
+                            log.warn('Received empty application types list from server; continuing to use default APPLICATION_TYPES.');
                         }
                     }, function (error) {
-                        alertsService.showError({ title: 'Error', message: error.data.message });
+                       var errorMessage = (error.data && error.data.message) || 'Failed to fetch application types';
+                        alertsService.showError({ title: 'Error', message: errorMessage });
                     });
                 }
                 

--- a/server/router.go
+++ b/server/router.go
@@ -35,8 +35,8 @@ func RouteAdminUIApi(mux *http.ServeMux, ProxyRequestHandler func(http.ResponseW
 	mux.HandleFunc("/environment/", ProxyRequestHandler)
 	mux.HandleFunc("/environment", ProxyRequestHandler)
 
-	mux.HandleFunc("/applicationtype/", ProxyRequestHandler)
-	mux.HandleFunc("/applicationtype", ProxyRequestHandler)
+	mux.HandleFunc("/application-types/", ProxyRequestHandler)
+	mux.HandleFunc("/application-types", ProxyRequestHandler)
 
 	mux.HandleFunc("/model/", ProxyRequestHandler)
 	mux.HandleFunc("/model", ProxyRequestHandler)

--- a/server/router.go
+++ b/server/router.go
@@ -35,6 +35,9 @@ func RouteAdminUIApi(mux *http.ServeMux, ProxyRequestHandler func(http.ResponseW
 	mux.HandleFunc("/environment/", ProxyRequestHandler)
 	mux.HandleFunc("/environment", ProxyRequestHandler)
 
+	mux.HandleFunc("/applicationtype/", ProxyRequestHandler)
+	mux.HandleFunc("/applicationtype", ProxyRequestHandler)
+
 	mux.HandleFunc("/model/", ProxyRequestHandler)
 	mux.HandleFunc("/model", ProxyRequestHandler)
 


### PR DESCRIPTION

- Implemented `getApplicationTypes` method in auth service to fetch application types from the server.

- Updated state configuration to call `fetchApplicationTypes` on initialization, storing results in `$rootScope`.

- Modified routing to handle `/applicationtype` endpoints for the new API.

- Enhanced existing logic to utilize fetched application types in the application.