### PR TITLE
 Add HTTPS/SSL Support

### DIFF
--- a/config/sample_xconfui.conf
+++ b/config/sample_xconfui.conf
@@ -20,12 +20,15 @@ xconfadminui {
     build_time = "Thu Feb 14 01:57:26 2024 UTC"
 
     server {
-        port = ":8081"
+        port = ":8443"
+        https_enabled = true                      // Enable HTTPS
+        cert_file = "/etc/ssl/xconf/xconf.crt"    // SSL certificate file
+        key_file = "/etc/ssl/xconf/xconf.key"     // SSL private key file
         web_root = "."
     }
 
     webconfigadmin {
-        host = "http://localhost:9001/xconfAdminService"
+        host = "https://localhost:9444/xconfAdminService"
     }
 
     log {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,17 @@ func main() {
 	app.RouteUiFiles(mux)
 
 	port := sc.GetString("xconfadminui.server.port")
-	log.Fatal(http.ListenAndServe(port, mux))
+	httpsEnabled := sc.GetBoolean("xconfadminui.server.https_enabled", false)
+	certFile := sc.GetString("xconfadminui.server.cert_file", "")
+	keyFile := sc.GetString("xconfadminui.server.key_file", "")
+	
+	if httpsEnabled && certFile != "" && keyFile != "" {
+		log.Info(fmt.Sprintf("Starting HTTPS server on port %s", port))
+		log.Fatal(http.ListenAndServeTLS(port, certFile, keyFile, mux))
+	} else {
+		log.Info(fmt.Sprintf("Starting HTTP server on port %s", port))
+		log.Fatal(http.ListenAndServe(port, mux))
+	}
 }
 
 func Index(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
   Adds HTTPS support to XConf services with TLS encryption.

   **Changes:**
   - Configure SSL/TLS in service config files
   - Update endpoints to use HTTPS (ports 9443, 9444, 8443)
   - Add certificate paths for TLS validation
   - Enable secure inter-service communication

   **Testing:** All services start and respond correctly on HTTPS endpoints.

   **Requirements:** SSL certificates at `/etc/ssl/xconf/xconf.crt` and `/etc/ssl/xconf/xconf.key`